### PR TITLE
docs: bump tested WP version and Tutor LMS compat

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: themeum
 Tags: education, e-commerce, blog, custom-logo, grid-layout, one-column, two-columns, custom-background, custom-colors, custom-header, custom-menu, featured-image-header, featured-images, flexible-header, full-width-template, sticky-post, theme-options, threaded-comments, translation-ready, rtl-language-support, footer-widgets, left-sidebar, right-sidebar
 Requires at least: 5.0
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 3.0.5
 Requires PHP: 7.4
 License: GPLv3 or later
@@ -85,7 +85,7 @@ If you found any bugs or issues, please let us know by posting on the support se
 == Changelog ==
 
 = 3.0.5 =
-Update : Added compatibility with Tutor LMS 4.0
+Update : Added compatibility with Tutor LMS 4.0.0
 
 = 3.0.4 =
 Update : Compatibility with latest WooCommerce

--- a/style.css
+++ b/style.css
@@ -3,8 +3,8 @@
  * Author: Themeum
  * Author URI: https://www.themeum.com
  * Description: Tutor Starter is a free WordPress LMS theme powered by Tutor LMS, the popular eLearning plugin for WordPress. It is designed to let Tutor LMS take center stage while also letting you pick what feels right. Tutor Starter is created with the same Unified Design System from Tutor LMS making it the perfect companion eLearning theme for Tutor LMS. Tutor Starter is also highly specialized for speed and efficiency, with all of its components optimized to give your eLearning website a great score on Google's PageSpeed. Tutor Starter pages are also schema ready and SEO optimized to make ranking on search engines as easy as pie! It also boasts an impressive blog single page for perfect readability. With full support for both Elementor and Gutenberg, Tutor Starter hopes to cater to the largest audience of both classic page builders and modern Gutenberg based builders. It comes with customizer settings for headers, footers, and everything in between. With several header and footer variations, advanced typography settings, and contextual page settings, create the eLearning website of your dreams with this free LMS theme. Tutor Starter features 3 modern and pre-built home layouts with fully functioning inner pages for both Elementor and Gutenberg to let you get started in no time. Tutor Starter also features a clean and light one-click demo importer to import all these pre-built home layouts for Gutenberg and Elementor. This, along with deep ties with Tutor LMS makes it a no-brainer WordPress LMS theme. Please Check theme demo here https://preview.tutorlms.com/
- * Tested up to:   6.9
- * Requires PHP:   7.4
+ * Tested up to: 7.0
+ * Requires PHP: 7.4
  * Version: 3.0.5
  * License: GNU General Public License v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
Update the Tested up to WordPress version from 6.9 to 7.0 in both readme.txt and style.css, and correct the 3.0.5 changelog entry to reference Tutor LMS 4.0.0 instead of 4.0